### PR TITLE
fix: resolving the Claude rendering issue

### DIFF
--- a/internal/formats/singlefile.go
+++ b/internal/formats/singlefile.go
@@ -104,7 +104,9 @@ func isAlwaysApply(content []byte) bool {
 		}
 	}
 
-	return false
+	// If alwaysApply is not explicitly set, default to true
+	// This ensures rules without the alwaysApply field are included in single-file formats
+	return true
 }
 
 // hasFrontmatter checks if a file has frontmatter

--- a/internal/formats/transform_test.go
+++ b/internal/formats/transform_test.go
@@ -284,6 +284,101 @@ Test content.`
 	}
 }
 
+func TestIsAlwaysApply(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name: "No frontmatter should return true",
+			content: `# Test Rule
+
+This is a test rule without frontmatter.`,
+			expected: true,
+		},
+		{
+			name: "Frontmatter with alwaysApply: true should return true",
+			content: `---
+alwaysApply: true
+description: "Test rule"
+---
+
+# Test Rule
+
+Test content.`,
+			expected: true,
+		},
+		{
+			name: "Frontmatter with alwaysApply: false should return false",
+			content: `---
+alwaysApply: false
+description: "Test rule"
+---
+
+# Test Rule
+
+Test content.`,
+			expected: false,
+		},
+		{
+			name: "Frontmatter with alwaysApply: 'true' (string) should return true",
+			content: `---
+alwaysApply: "true"
+description: "Test rule"
+---
+
+# Test Rule
+
+Test content.`,
+			expected: true,
+		},
+		{
+			name: "Frontmatter with alwaysApply: 'false' (string) should return false",
+			content: `---
+alwaysApply: "false"
+description: "Test rule"
+---
+
+# Test Rule
+
+Test content.`,
+			expected: false,
+		},
+		{
+			name: "Frontmatter without alwaysApply field should return true (default behavior)",
+			content: `---
+name: "Next.js + Common Libraries"
+description: "Test rule"
+---
+
+# Test Rule
+
+Test content.`,
+			expected: true,
+		},
+		{
+			name: "Empty frontmatter should return true",
+			content: `---
+---
+
+# Test Rule
+
+Test content.`,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isAlwaysApply([]byte(tt.content))
+			if result != tt.expected {
+				t.Errorf("isAlwaysApply() = %v, expected %v for content:\n%s", result, tt.expected, tt.content)
+			}
+		})
+	}
+}
+
 func TestTransformRuleContent_CursorFallback(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
# What is this?

fixes #22 

User reported the basic example in the docs is not working when running `render claude`. After a quick triage it is due to the `alwaysApply` not existing in the `starter/nextjs-rules` rules does not included this frontmatter and the rendering specifically is looking for that.  