### PR TITLE
feat(tests): add cross-platform test utilities

### DIFF
--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+func testBinaryName(name string) string {
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return name
+}
+
+func cleanupTestPath(t *testing.T, path string) {
+	t.Helper()
+	if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("Failed to remove %s: %v", path, err)
+	}
+}

--- a/tests/golden_test.go
+++ b/tests/golden_test.go
@@ -139,7 +139,7 @@ func TestGoldenFiles(t *testing.T) {
 	}
 
 	// Make sure the CLI binary exists
-	cliPath := "../rules-cli"
+	cliPath := testBinaryName("../rules-cli")
 	if _, err := os.Stat(cliPath); os.IsNotExist(err) {
 		// Build the CLI if it doesn't exist
 		// Get version from package.json
@@ -159,7 +159,8 @@ func TestGoldenFiles(t *testing.T) {
 	for _, goldenFile := range goldenFiles {
 		t.Run(goldenFile, func(t *testing.T) {
 			// Look up the command for this golden file
-			cmd, found := goldenToCommand["tests/"+goldenFile]
+			slashPath := filepath.ToSlash(goldenFile)
+			cmd, found := goldenToCommand["tests/"+slashPath]
 			if !found {
 				t.Skipf("No command configured for golden file: %s", goldenFile)
 				return
@@ -170,10 +171,10 @@ func TestGoldenFiles(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create temporary directory: %v", err)
 			}
-			defer os.RemoveAll(tempDir)
+			defer cleanupTestPath(t, tempDir)
 
 			// Copy the CLI binary to the temporary directory
-			tempCliPath := filepath.Join(tempDir, "rules-cli")
+			tempCliPath := filepath.Join(tempDir, testBinaryName("rules-cli"))
 			if err := copyFile(cliPath, tempCliPath); err != nil {
 				t.Fatalf("Failed to copy CLI binary: %v", err)
 			}
@@ -243,6 +244,7 @@ func TestGoldenFiles(t *testing.T) {
 			// Normalize line endings for cross-platform compatibility
 			expected = strings.ReplaceAll(expected, "\r\n", "\n")
 			actual = strings.ReplaceAll(actual, "\r\n", "\n")
+			actual = filepath.ToSlash(actual)
 
 			// Special case for login test which has placeholders
 			if strings.Contains(expected, "<STATE_PLACEHOLDER>") {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -30,16 +30,18 @@ func TestCLIIntegration(t *testing.T) {
 			// Get the parent directory (project root)
 			parentDir := filepath.Join("..", ".")
 
+			binaryName := testBinaryName("rules-test")
 			// Build the CLI from the parent directory
-			buildCmd := exec.Command("go", "build", "-o", "rules-test", ".")
+			buildCmd := exec.Command("go", "build", "-o", binaryName, ".")
 			buildCmd.Dir = parentDir
 			if err := buildCmd.Run(); err != nil {
 				t.Fatalf("Failed to build CLI: %v", err)
 			}
-			defer exec.Command("rm", "-f", filepath.Join(parentDir, "rules-test")).Run()
+			binaryPath := filepath.Join(parentDir, binaryName)
+			defer cleanupTestPath(t, binaryPath)
 
 			// Run the CLI command
-			cmd := exec.Command(filepath.Join(parentDir, "rules-test"), tt.args...)
+			cmd := exec.Command(binaryPath, tt.args...)
 			output, err := cmd.CombinedOutput()
 
 			// For help and version commands, exit code 0 is expected
@@ -58,14 +60,16 @@ func TestCLICommandsExist(t *testing.T) {
 	// Test that expected commands exist
 	parentDir := filepath.Join("..", ".")
 
-	buildCmd := exec.Command("go", "build", "-o", "rules-test", ".")
+	binaryName := testBinaryName("rules-test")
+	buildCmd := exec.Command("go", "build", "-o", binaryName, ".")
 	buildCmd.Dir = parentDir
 	if err := buildCmd.Run(); err != nil {
 		t.Fatalf("Failed to build CLI: %v", err)
 	}
-	defer exec.Command("rm", "-f", filepath.Join(parentDir, "rules-test")).Run()
+	binaryPath := filepath.Join(parentDir, binaryName)
+	defer cleanupTestPath(t, binaryPath)
 
-	cmd := exec.Command(filepath.Join(parentDir, "rules-test"), "--help")
+	cmd := exec.Command(binaryPath, "--help")
 	output, _ := cmd.CombinedOutput()
 
 	// Check for expected subcommands


### PR DESCRIPTION
## Description

Introduce common_test.go with helper functions for cross-platform testing:
- `testBinaryName()` handles platform-specific binary extensions
- `cleanupTestPath()` provides consistent test cleanup
- Normalize paths with `filepath.ToSlash()` for consistent comparisons 

Refactor tests to use these utilities for better Windows compatibility.