### PR TITLE
docs: Correct path for "download from GitHub" add rules example

### DIFF
--- a/docs-main/index.mdx
+++ b/docs-main/index.mdx
@@ -32,7 +32,7 @@ This will add them to your project in a local `.rules` folder.
 You can also download from GitHub rather than the rules registry:
 
 ```bash
-rules add gh:continuedev/awesome-rules/ruby
+rules add gh:continuedev/awesome-rules/rules/ruby
 ```
 
 ## Render rules


### PR DESCRIPTION
Rule paths in the `:continuedev/awesome-rules` have changed. Update the file path in the "download from GitHub" example to ensure users can correctly access the example rules.
